### PR TITLE
Do not read alpha channel with ffms2

### DIFF
--- a/getnative.py
+++ b/getnative.py
@@ -351,7 +351,7 @@ def _get_source_filter(args):
     source_filter = _get_attr(core, 'ffms2.Source')
     if source_filter:
         print("Using ffms2 as source filter")
-        return source_filter
+        return lambda input_file: source_filter(input_file, alpha=False)
     source_filter = _get_attr(core, 'lsmas.LWLibavSource')
     if source_filter:
         print("Using lsmas.LWLibavSource as source filter")


### PR DESCRIPTION
Currently this script fails when the loaded image has an alpha channel:

```
[…]
  File "/usr/local/lib/python3.7/dist-packages/getnative.py", line 282, in getnative
    args.frame = src.num_frames // 3
AttributeError: 'list' object has no attribute 'num_frames'
```

This is because (when the `alpha` parameter is set to `True`) ffms2 outputs the alpha channel as a second clip and therefore returns a list of `VideoNode`s instead of a single `VideoNode`. The parameter should be [disabled by default](https://github.com/FFMS/ffms2/blob/master/doc/ffms2-vapoursynth.md#bint-alpha--false), but (at least in my distribution) isn’t.

This PR modifies the returned ffms2 source function so the `alpha` parameter is always `False`.