### PR TITLE
Allow python3 -m getnative to run the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Install it via:
 Start by executing:
 
     $ getnative [--args] inputFile
+    
+If `getnative` could not be found, try executing this:
+
+    # Linux
+    $ python -m getnative [--args] inputFile
+    
+    # Windows
+    $ py -3 -m getnative [--args] inputFile
 
 ***or***  
   
@@ -16,7 +24,7 @@ Install all depdencies through `pip`
 
 Start by executing:
 
-    $ python run_getnative.py [--args] inputFile
+    $ python -m getnative [--args] inputFile
 
 That's it.
 

--- a/getnative/__main__.py
+++ b/getnative/__main__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+# Make sure the CLI-Parser does not print out __main__.py
+import sys, os
+sys.argv[0] = os.path.dirname(sys.argv[0])
+
+# Run getnatvie.
+from getnative import app
+app.main()

--- a/run_getnative.py
+++ b/run_getnative.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-
-from getnative import app
-
-
-if __name__ == "__main__":
-    app.main()


### PR DESCRIPTION
Unofficially:
This is for those shitty windows users where putting it into path by PIP doesn't work.

Officially:
It is generally considered good practise to allow prepending "python3 -m " to the actual getnative-call to run the application because in some cases PIP fails to add the console-script to PATH.