### PR TITLE
Add VapourSynth R60 support

### DIFF
--- a/getnative/app.py
+++ b/getnative/app.py
@@ -309,7 +309,7 @@ async def getnative(args: Union[List, argparse.Namespace], src: vapoursynth.Vide
         scaler = scaler
 
     if scaler.plugin is None:
-        if "toggaf.asi.xe" in core.get_plugins():
+        if "toggaf.asi.xe" in (core.get_plugins() if core.version_number() < 60 else core.plugins()):
             print("Error: descale_getnative support ended, pls use https://github.com/Irrational-Encoding-Wizardry/vapoursynth-descale")
         raise GetnativeException('No descale found!')
 

--- a/getnative/app.py
+++ b/getnative/app.py
@@ -309,7 +309,12 @@ async def getnative(args: Union[List, argparse.Namespace], src: vapoursynth.Vide
         scaler = scaler
 
     if scaler.plugin is None:
-        if "toggaf.asi.xe" in (core.get_plugins() if core.version_number() < 60 else core.plugins()):
+        if core.version_number() < 60:
+            identifiers = core.get_plugins()
+        else:
+            identifiers = [plugin.identifier for plugin in core.plugins()]
+
+        if "toggaf.asi.xe" in identifiers:
             print("Error: descale_getnative support ended, pls use https://github.com/Irrational-Encoding-Wizardry/vapoursynth-descale")
         raise GetnativeException('No descale found!')
 

--- a/getnative/utils.py
+++ b/getnative/utils.py
@@ -1,14 +1,14 @@
 import os
 import argparse
 import vapoursynth
-from typing import Union, Callable
+from typing import Union
 
 
 class GetnativeException(BaseException):
     pass
 
 
-def plugin_from_identifier(core: vapoursynth.Core, identifier: str) -> Union[Callable, None]:
+def plugin_from_identifier(core: vapoursynth.Core, identifier: str) -> Union[vapoursynth.Plugin, None]:
     """
     Get a plugin from vapoursynth with only the plugin identifier
 
@@ -17,11 +17,10 @@ def plugin_from_identifier(core: vapoursynth.Core, identifier: str) -> Union[Cal
     :return Plugin or None
     """
 
-    return getattr(
-        core,
-        core.get_plugins().get(identifier, {}).get("namespace", ""),
-        None
-    )
+    if core.version_number() >= 60:
+        return next((plugin for plugin in core.plugins() if plugin.identifier == identifier), None)
+
+    return getattr(core, core.get_plugins().get(identifier, {}).get("namespace", ""), None)  # type: ignore
 
 
 def vpy_source_filter(path):


### PR DESCRIPTION
This commit https://github.com/vapoursynth/vapoursynth/commit/d7884782b3d4dac8ebc210a66d14a94b3843ef54 removed old deprecated functions in the python API that are being used in this package