### PR TITLE
Merge branch AmusementClub/mod

### DIFF
--- a/getnative/app.py
+++ b/getnative/app.py
@@ -90,6 +90,7 @@ common_scaler = {
         _DefineScaler("bicubic", b=1 / 3, c=1 / 3),
         _DefineScaler("bicubic", b=.5, c=0),
         _DefineScaler("bicubic", b=0, c=.5),
+        _DefineScaler("bicubic", b=0, c=.75),
         _DefineScaler("bicubic", b=1, c=0),
         _DefineScaler("bicubic", b=0, c=1),
         _DefineScaler("bicubic", b=.2, c=.5),

--- a/getnative/utils.py
+++ b/getnative/utils.py
@@ -38,14 +38,14 @@ def get_source_filter(core, imwri, args):
     if ext in {".py", ".pyw", ".vpy"}:
         print("Using custom VapourSynth script as a source. This may cause garbage results. Only do this if you know what you are doing.")
         return vpy_source_filter
-    source_filter = get_attr(core, 'ffms2.Source')
-    if source_filter:
-        print("Using ffms2 as source filter")
-        return lambda input_file: source_filter(input_file, alpha=False)
     source_filter = get_attr(core, 'lsmas.LWLibavSource')
     if source_filter:
         print("Using lsmas.LWLibavSource as source filter")
         return source_filter
+    source_filter = get_attr(core, 'ffms2.Source')
+    if source_filter:
+        print("Using ffms2 as source filter")
+        return lambda input_file: source_filter(input_file, alpha=False)
     source_filter = get_attr(core, 'lsmas.LSMASHVideoSource')
     if source_filter:
         print("Using lsmas.LSMASHVideoSource as source filter")


### PR DESCRIPTION
`b=0` and `c=3/4` are used by OpenCV and allegedly Adobe After Effects. I have seen anime BDs that use those parameters, so it seems sensible to include this kernel.

In the past two years, Akarin has become the maintainer of the LSMASH fork that everyone uses, including the one vsrepo points to, and the old screenshot source bug seems to be gone. I have not been able to produce any problems with image or video sources while ffms2 still occasionally fails for some video sources, especially DVDs, so this seems to be a better default now.