### PR TITLE
Update README.md Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ To run this script you will need:
  \*imwri: ImageMagick7 is required for macOS and Linux 
 
 #### Installation
-Install it via:
+After installing the above prerequisites, install the project via:
 
     $ pip install getnative
 
 **or**
 
 * Download all files from github  
-* Install all dependencies through `pip install -r requirements.txt`  
+* Install all Python dependencies through `pip install -r requirements.txt`  
 
 #### Recommended Windows Installation
 


### PR DESCRIPTION
I ran into the same issue as https://github.com/Infiziert90/getnative/issues/22, because the current instructions aren't clear that the pip package doesn't handle the external dependencies, and the error message isn't helpful, so this pull strives to clarify. 

I then discovered Vapoursynth oddly isn't packaged for Ubuntu (available for Deb but not Ubuntu is a new one for me...) and don't have time to fiddle with building from source at the moment so I still haven't installed, but that's a separate issue.